### PR TITLE
updated to build with sbt-0.13.11 and scala-2.10.5

### DIFF
--- a/plugin/src/main/scala/sbt2nix/NixPlugin.scala
+++ b/plugin/src/main/scala/sbt2nix/NixPlugin.scala
@@ -172,7 +172,7 @@ object NixPlugin extends Plugin {
   def setting[A](key: SettingKey[A], state: State): Validation[A] =
     key get structure(state).data match {
       case Some(a) => a.success
-      case None => "Undefined setting '%s'!".format(key.key).failNel
+      case None => "Undefined setting '%s'!".format(key.key).failureNel
     }
 
   def javacVersion(javacOptions: Seq[String]): String = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,9 +10,9 @@ object Build extends Build {
     settings = commonSettings ++ Seq(
       name := "sbt2nix",
       libraryDependencies ++= Seq(
-       "commons-codec"  % "commons-codec"  % "1.6",
-        "org.scalaz"  %% "scalaz-core"  % "7.0.2",
-       "org.scalaz" %% "scalaz-effect" % "7.0.2")
+        "commons-codec"  % "commons-codec"  % "1.6",
+        "org.scalaz"  %% "scalaz-core"  % "7.3.0-M3",
+        "org.scalaz" %% "scalaz-effect" % "7.3.0-M3")
     )
   )
 
@@ -28,7 +28,7 @@ object Build extends Build {
         System.getProperty("sbt.build.version", sbtVersion)
       },
       scalaVersion <<= (sbtVersion in GlobalScope) {
-        case sbt013 if sbt013.startsWith("0.13.") => "2.10.4"
+        case sbt013 if sbt013.startsWith("0.13.") => "2.10.5"
         case sbt012 if sbt012.startsWith("0.12.") => "2.9.3"
         case _ => "2.9.3"
       },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.11


### PR DESCRIPTION
These versions are the ones used by nixpkgs (as of release 16.03, and df89584), which allows to build `sbt2nix` out of the box in Nix.
